### PR TITLE
allow calculation of well-separated dimer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ Most recent change on the bottom.
 
 ### Fixed
 - Typo of `latent_resent` -> `latent_resnet`
+- Allow energy calculation of well-separated dimers

--- a/allegro/nn/_allegro.py
+++ b/allegro/nn/_allegro.py
@@ -497,6 +497,12 @@ class Allegro_Module(GraphModuleMixin, torch.nn.Module):
             active_edges = (cutoff_coeffs > 0).nonzero().squeeze(-1)
 
             # Compute latents
+            for i in range(len(latent_inputs_to_cat)):
+                oldshape=latent_inputs_to_cat[i].shape
+                if len(latent_inputs_to_cat[i].shape)==1:
+                    latent_inputs_to_cat[i]=\
+                        latent_inputs_to_cat[i].reshape((oldshape[0],1))
+            
             new_latents = latent(torch.cat(latent_inputs_to_cat, dim=-1)[prev_mask])
             # Apply cutoff, which propagates through to everything else
             new_latents = cutoff_coeffs[active_edges].unsqueeze(-1) * new_latents
@@ -582,9 +588,14 @@ class Allegro_Module(GraphModuleMixin, torch.nn.Module):
             # Get invariants
             # features has shape [z][mul][k]
             # we know scalars are first
-            scalars = features[:, :, : self._n_scalar_outs[layer_index]].reshape(
-                features.shape[0], -1
-            )
+
+            oldshape = features[:, :, : self._n_scalar_outs[layer_index]].shape
+            newshape = (oldshape[0],oldshape[1]*oldshape[2])
+            scalars = features[:, :, : self._n_scalar_outs[layer_index]].reshape( newshape )
+            # The -1 breaks when there's an atom without an edge
+            # scalars = features[:, :, : self._n_scalar_outs[layer_index]].reshape(
+            #     features.shape[0], -1
+            # )
 
             # do the linear
             features = linear(features)

--- a/allegro/nn/_allegro.py
+++ b/allegro/nn/_allegro.py
@@ -152,7 +152,7 @@ class Allegro_Module(GraphModuleMixin, torch.nn.Module):
             if layer_idx == 0:
                 # Add parity irreps
                 ir_out = []
-                for (mul, ir) in env_embed_irreps:
+                for mul, ir in env_embed_irreps:
                     if self.nonscalars_include_parity:
                         # add both parity options
                         ir_out.append((1, (ir.l, 1)))
@@ -498,11 +498,12 @@ class Allegro_Module(GraphModuleMixin, torch.nn.Module):
 
             # Compute latents
             for i in range(len(latent_inputs_to_cat)):
-                oldshape=latent_inputs_to_cat[i].shape
-                if len(latent_inputs_to_cat[i].shape)==1:
-                    latent_inputs_to_cat[i]=\
-                        latent_inputs_to_cat[i].reshape((oldshape[0],1))
-            
+                oldshape = latent_inputs_to_cat[i].shape
+                if len(latent_inputs_to_cat[i].shape) == 1:
+                    latent_inputs_to_cat[i] = latent_inputs_to_cat[i].reshape(
+                        (oldshape[0], 1)
+                    )
+
             new_latents = latent(torch.cat(latent_inputs_to_cat, dim=-1)[prev_mask])
             # Apply cutoff, which propagates through to everything else
             new_latents = cutoff_coeffs[active_edges].unsqueeze(-1) * new_latents
@@ -590,8 +591,10 @@ class Allegro_Module(GraphModuleMixin, torch.nn.Module):
             # we know scalars are first
 
             oldshape = features[:, :, : self._n_scalar_outs[layer_index]].shape
-            newshape = (oldshape[0],oldshape[1]*oldshape[2])
-            scalars = features[:, :, : self._n_scalar_outs[layer_index]].reshape( newshape )
+            newshape = (oldshape[0], oldshape[1] * oldshape[2])
+            scalars = features[:, :, : self._n_scalar_outs[layer_index]].reshape(
+                newshape
+            )
             # The -1 breaks when there's an atom without an edge
             # scalars = features[:, :, : self._n_scalar_outs[layer_index]].reshape(
             #     features.shape[0], -1

--- a/allegro/nn/_edgewise.py
+++ b/allegro/nn/_edgewise.py
@@ -101,6 +101,16 @@ class EdgewiseEnergySum(GraphModuleMixin, torch.nn.Module):
 
         edge_eng = data[_keys.EDGE_ENERGY]
         species = data[AtomicDataDict.ATOM_TYPE_KEY].squeeze(-1)
+
+        if len(species.shape) == 0:
+            newshape=list(edge_eng.shape)
+            newshape[0]=1
+            data[AtomicDataDict.PER_ATOM_ENERGY_KEY] = \
+                torch.zeros( newshape,
+                             dtype=edge_eng.dtype,
+                             device=edge_eng.device )
+            return data
+        
         center_species = species[edge_center]
         neighbor_species = species[edge_neighbor]
 

--- a/allegro/nn/_edgewise.py
+++ b/allegro/nn/_edgewise.py
@@ -32,9 +32,11 @@ class EdgewiseReduce(GraphModuleMixin, torch.nn.Module):
         self.out_field = f"{reduce}_{field}" if out_field is None else out_field
         self._init_irreps(
             irreps_in=irreps_in,
-            irreps_out={self.out_field: irreps_in[self.field]}
-            if self.field in irreps_in
-            else {},
+            irreps_out=(
+                {self.out_field: irreps_in[self.field]}
+                if self.field in irreps_in
+                else {}
+            ),
         )
         self._factor = None
         if normalize_edge_reduce and avg_num_neighbors is not None:
@@ -103,14 +105,13 @@ class EdgewiseEnergySum(GraphModuleMixin, torch.nn.Module):
         species = data[AtomicDataDict.ATOM_TYPE_KEY].squeeze(-1)
 
         if len(species.shape) == 0:
-            newshape=list(edge_eng.shape)
-            newshape[0]=1
-            data[AtomicDataDict.PER_ATOM_ENERGY_KEY] = \
-                torch.zeros( newshape,
-                             dtype=edge_eng.dtype,
-                             device=edge_eng.device )
+            newshape = list(edge_eng.shape)
+            newshape[0] = 1
+            data[AtomicDataDict.PER_ATOM_ENERGY_KEY] = torch.zeros(
+                newshape, dtype=edge_eng.dtype, device=edge_eng.device
+            )
             return data
-        
+
         center_species = species[edge_center]
         neighbor_species = species[edge_neighbor]
 


### PR DESCRIPTION
When an atom is isolated, there are no edges, and the array dimensions can be 0. This causes ambiguity problems when trying to use -1 as an argument to reshape. The proposed modifications catch a few cases where the 0-sized dimensions prevent calculation of well-separated dimers. For more info, see https://github.com/mir-group/allegro/discussions/82  In the context of that discussion, these changes let the following command work, whereas the original version did not: `plot_dimers.py --r-min=5.1 --r-max=5.2 --n-samples 2 si-deployed.pth`

To calculate the energy of isolated atoms (as opposed to well-separated dimers), one needs to make modifications to nequip. Those modifications can be found here: https://github.com/mir-group/nequip/pull/426