### PR TITLE
Allow calculation of well-separated dimers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ Most recent change on the bottom.
 
 ### Fixed
 - Typo of `latent_resent` -> `latent_resnet`
+- Allow calculation of well-separated dimers when the batch has no edges

--- a/allegro/nn/_edgewise.py
+++ b/allegro/nn/_edgewise.py
@@ -101,6 +101,15 @@ class EdgewiseEnergySum(GraphModuleMixin, torch.nn.Module):
 
         edge_eng = data[_keys.EDGE_ENERGY]
         species = data[AtomicDataDict.ATOM_TYPE_KEY].squeeze(-1)
+
+        if len(species.shape) == 0:
+            newshape = list(edge_eng.shape)
+            newshape[0] = 1
+            data[AtomicDataDict.PER_ATOM_ENERGY_KEY] = torch.zeros(
+                newshape, dtype=edge_eng.dtype, device=edge_eng.device
+            )
+            return data
+
         center_species = species[edge_center]
         neighbor_species = species[edge_neighbor]
 


### PR DESCRIPTION
When an atom is isolated, there are no edges, and the array dimensions can be 0. This causes ambiguity problems when trying to use -1 as an argument to reshape. The proposed modifications catch a few cases where the 0-sized dimensions prevent calculation of well-separated dimers. For more info, see #82 In the context of that discussion, these changes let the following command work, whereas the original version did not: plot_dimers.py --r-min=5.1 --r-max=5.2 --n-samples 2 si-deployed.pth

To calculate the energy of isolated atoms (as opposed to well-separated dimers), one needs to make modifications to nequip. Those modifications can be found here: mir-group/nequip#426

This pull request is merge into the develop branch, whereas the closed request #83 was a merge into main.